### PR TITLE
Refactor JobDetails

### DIFF
--- a/backend/src/mockdata.ts
+++ b/backend/src/mockdata.ts
@@ -24,10 +24,14 @@ export const mockUserWithRating: UserWithRating = {
 }
 
 export const mockJobDetails: IJobDetails = {
+  title: 'Brick delivery',
+  description: 'Please deliver it!',
+  clientId: "randomMongoDbId",
+  transporterId: "randomMongoDbId",
+  deliveryId: 'randomMongoDbId',
   clientName: 'John Doe',
-  transporterName: 'Doe John',
+  clientAvgRating: 4.5,
   imPaths: 'https://cdn-icons-png.flaticon.com/512/685/685681.png',
-  avgRating: 4.5,
   deliveryDate: new Date('2019-01-16'),
   deliveryCost: 10000,
   deliveryLocation: {
@@ -39,10 +43,7 @@ export const mockJobDetails: IJobDetails = {
     address: 'Irinyi József utca 42',
     city: 'Budapest',
     postalCode: 1117
-  },
-  _id: 'randomMongoDbId',
-  title: 'Brick delivery',
-  description: 'Please deliver it!'
+  }
 }
 
 export const mockUserInToplist: IUserInToplist = {

--- a/backend/src/types/JobDetails.ts
+++ b/backend/src/types/JobDetails.ts
@@ -1,13 +1,14 @@
 import { ILocation } from './location'
 
 export interface IJobDetails {
-  _id: string
   title: string
   description: string
+  clientId: string
+  transporterId?: string
+  deliveryId: string
   clientName: string
-  transporterName?: string
+  clientAvgRating: number
   imPaths: string
-  avgRating: number
   deliveryDate: Date
   deliveryCost: number
   deliveryLocation: ILocation


### PR DESCRIPTION
Szerintetek jó lenne, ha megváltoztatnánk így a JobDetails objektumot?
 - A transporterId és clientId szerintem mindenképpen kelleni fog, mert felesleges lenne kliens oldalon egy plusz lekérdezéssel megszerezni őket.
 - A transporterName-t kivettem, mert ha szükség van rá, úgy is egyszerűbb a értékeléssel együtt lekérdezni.